### PR TITLE
chore(setup): Setup docker compose for development.

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+
+dist/
+target/
+
+README.md
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-target/
 dist/
+target/

--- a/Justfile
+++ b/Justfile
@@ -1,0 +1,22 @@
+set dotenv-load
+
+export RUST_LOG := 'info'
+
+@default:
+	just --list
+
+
+@dev:
+	#!/bin/bash
+	set -e
+
+	if
+		[[ -f /.dockerenv ]] ||
+		grep -qE '(docker|containerd|kubepods)' /proc/1/cgroup 2>/dev/null;
+	then
+		cargo run -p backend 2>&1 &
+		trunk serve --config Trunk.toml 2>&1 &
+		wait
+	else
+		docker compose -f ./docker/dev.docker-compose.yml up --no-deps --build;
+	fi

--- a/Trunk.toml
+++ b/Trunk.toml
@@ -4,6 +4,7 @@ target = "core/frontend/index.html"
 dist = "dist/"
 
 [serve]
+addresses = ["0.0.0.0"]
 port = 8080
 open = true
 

--- a/core/backend/src/main.rs
+++ b/core/backend/src/main.rs
@@ -15,7 +15,7 @@ async fn main() -> Result<(), AppError> {
         App::new()
             .route("/", get().to(async || HttpResponse::Ok().body("Hello World!")))
     })
-        .bind(("0.0.0.0", 8080))?
+        .bind(("0.0.0.0", 8081))?
         .run()
         .await?;
 

--- a/docker/dev.docker-compose.yml
+++ b/docker/dev.docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  app:
+    container_name: canva_dot
+    build:
+      dockerfile: dev.dockerfile
+    volumes:
+      - ../:/home/dev/canvadot
+    ports:
+      - 8080:8080
+      - 8081:8081
+

--- a/docker/dev.dockerfile
+++ b/docker/dev.dockerfile
@@ -1,0 +1,27 @@
+FROM nim65s/cargo-binstall AS installer
+
+RUN cargo binstall -y --locked \
+	trunk \
+	cargo-watch \
+	just
+
+FROM rust:1.89-bookworm
+
+ENV DEBIAN_FRONTEND=nointeractive
+
+RUN useradd -m dev
+WORKDIR /home/dev/canvadot
+USER dev
+
+ENV PATH="/home/dev/.cargo/bin:$PATH"
+
+COPY --from=installer /usr/local/cargo/bin/cargo-watch /home/dev/.cargo/bin/cargo-watch
+COPY --from=installer /usr/local/cargo/bin/trunk /home/dev/.cargo/bin/trunk
+COPY --from=installer /usr/local/cargo/bin/just /home/dev/.cargo/bin/just
+
+RUN rustup target add wasm32-unknown-unknown
+
+EXPOSE 8080
+EXPOSE 8081
+
+CMD just dev


### PR DESCRIPTION
This PR contains the development setup, the just file and docker configuration to start up the project in development mode.

Within the development container, docker-compose exposes the port `8080` for the frontend, so you are able to access it trough `0.0.0.0:8080/*` and the backend is reverse-proxied with a rewrite at `0.0.0.0:8080/api/*`.

In the production container, this should be replicated with nginx unless plans change.